### PR TITLE
Downgrade the runtime to GNOME 42

### DIFF
--- a/com.hack_computer.Sidetrack.json
+++ b/com.hack_computer.Sidetrack.json
@@ -9,7 +9,7 @@
       }
   },
   "runtime": "org.gnome.Platform",
-  "runtime-version": "43",
+  "runtime-version": "42",
   "sdk": "org.gnome.Sdk",
   "command": "com.hack_computer.Sidetrack",
   "finish-args": [
@@ -46,7 +46,7 @@
         {
           "type": "git",
           "url": "https://github.com/endlessm/hack-toy-apps.git",
-          "commit": "0313b4656c1515706205257fa1e7be8f93503915"
+          "commit": "ef214fb25ec4a14b9f426c215d13a5527e67d054"
         }
       ]
     }


### PR DESCRIPTION
The Asyncio of clubhouse has compatibility issue with Python 3.10+ [1]. And, GNOME 43 runtime has Python 3.10. However, we has not had a way to fix the issue, yet. Therefore, downgrade the runtime to GNOME 42 to gain more time to fix the Asyncio compatibilty issue between clubhouse and Python 3.10+.

Follow the commit ("Downgrade the runtime to GNOME 42") of upstream clippy [2].

[1]: https://github.com/flathub/com.hack_computer.Clubhouse/issues/22#issuecomment-1352841349
[2]: https://github.com/endlessm/clippy